### PR TITLE
Add LightGBM training and evaluation scripts

### DIFF
--- a/pipelines/sainsbury/evaluate.py
+++ b/pipelines/sainsbury/evaluate.py
@@ -1,49 +1,119 @@
-"""Evaluation script for classification accuracy."""
+"""Evaluate LightGBM models on the test set."""
 import json
 import logging
+import os
 import pathlib
 import pickle
 import tarfile
 
-import numpy as np
 import pandas as pd
-import xgboost
-from sklearn.metrics import accuracy_score
+from sklearn.metrics import (
+    accuracy_score,
+    precision_score,
+    recall_score,
+    f1_score,
+    roc_auc_score,
+    average_precision_score,
+)
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler())
+FEATURES = [
+    "Supplier",
+    "HierarchyLevel1",
+    "HierarchyLevel2",
+    "DIorDOM",
+    "Seasonal",
+    "SpringSummer",
+    "Status",
+    "SalePriceIncVAT",
+    "ForecastPerWeek",
+    "ActualsPerWeek",
+    "WeeksOut",
+]
+TARGET = "DiscontinuedTF"
+HORIZONS = [-12, -8, -4]
+
+COLUMNS = [
+    "DiscontinuedTF",
+    "CatEdition",
+    "SpringSummer",
+    "ProductKey",
+    "WeeksOut",
+    "Status",
+    "SalePriceIncVAT",
+    "ForecastPerWeek",
+    "ActualsPerWeek",
+    "Fcast_to_Actual",
+    "Supplier",
+    "HierarchyLevel1",
+    "HierarchyLevel2",
+    "DIorDOM",
+    "Seasonal",
+]
+
+
+def _load_dataset(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path, header=None, names=COLUMNS)
+    for col in [
+        "Supplier",
+        "HierarchyLevel1",
+        "HierarchyLevel2",
+        "DIorDOM",
+        "Seasonal",
+        "SpringSummer",
+        "Status",
+    ]:
+        if col in df.columns:
+            df[col] = df[col].astype("category")
+    return df
+
+
+def get_data_for_horizon(df: pd.DataFrame, horizon: int):
+    subset = df[df["WeeksOut"] == horizon].copy()
+    X = subset[FEATURES]
+    y = subset[TARGET]
+    return X, y
+
 
 if __name__ == "__main__":
-    logger.debug("Starting evaluation.")
+    logging.basicConfig(level=logging.INFO)
+
     model_path = "/opt/ml/processing/model/model.tar.gz"
     with tarfile.open(model_path) as tar:
         tar.extractall(path=".")
 
-    logger.debug("Loading xgboost model.")
-    model = pickle.load(open("xgboost-model", "rb"))
-
-    logger.debug("Reading test data.")
     test_path = "/opt/ml/processing/test/test.csv"
-    df = pd.read_csv(test_path, header=None)
+    test_df = _load_dataset(test_path)
 
-    y_test = df.iloc[:, 0].to_numpy()
-    X_test = xgboost.DMatrix(df.drop(df.columns[0], axis=1).values)
+    overall_true = []
+    overall_pred = []
+    metrics = {}
 
-    logger.info("Performing predictions against test data.")
-    preds = model.predict(X_test)
-    pred_labels = (preds > 0.5).astype(int)
+    for horizon in HORIZONS:
+        model_file = f"model_horizon_{horizon}w.pkl"
+        with open(model_file, "rb") as f:
+            model = pickle.load(f)
+        X_test, y_test = get_data_for_horizon(test_df, horizon)
+        y_pred = model.predict(X_test)
+        y_proba = model.predict_proba(X_test)[:, 1]
+        metrics[str(horizon)] = {
+            "accuracy": accuracy_score(y_test, y_pred),
+            "precision": precision_score(y_test, y_pred),
+            "recall": recall_score(y_test, y_pred),
+            "f1": f1_score(y_test, y_pred),
+            "roc_auc": roc_auc_score(y_test, y_proba),
+            "pr_auc": average_precision_score(y_test, y_proba),
+        }
+        overall_true.extend(y_test)
+        overall_pred.extend(y_pred)
 
-    logger.debug("Calculating accuracy.")
-    acc = accuracy_score(y_test, pred_labels)
+    overall_accuracy = accuracy_score(overall_true, overall_pred)
     report_dict = {
-        "classification_metrics": {"accuracy": {"value": acc}}
+        "classification_metrics": {"accuracy": {"value": overall_accuracy}},
+        "per_horizon_metrics": metrics,
     }
 
     output_dir = "/opt/ml/processing/evaluation"
     pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
-
-    logger.info("Writing out evaluation report with accuracy: %f", acc)
-    evaluation_path = f"{output_dir}/evaluation.json"
+    evaluation_path = os.path.join(output_dir, "evaluation.json")
     with open(evaluation_path, "w") as f:
         f.write(json.dumps(report_dict))

--- a/pipelines/sainsbury/train.py
+++ b/pipelines/sainsbury/train.py
@@ -1,0 +1,130 @@
+"""Train LightGBM models per forecast horizon."""
+import os
+import pickle
+
+import pandas as pd
+import lightgbm as lgb
+from lightgbm import early_stopping, log_evaluation
+
+FEATURES = [
+    "Supplier",
+    "HierarchyLevel1",
+    "HierarchyLevel2",
+    "DIorDOM",
+    "Seasonal",
+    "SpringSummer",
+    "Status",
+    "SalePriceIncVAT",
+    "ForecastPerWeek",
+    "ActualsPerWeek",
+    "WeeksOut",
+]
+TARGET = "DiscontinuedTF"
+HORIZONS = [-12, -8, -4]
+MODEL_DIR = "/opt/ml/model"
+PREDICTION_DIR = "/opt/ml/output/predictions"
+
+# column names as produced by preprocess.py
+COLUMNS = [
+    "DiscontinuedTF",
+    "CatEdition",
+    "SpringSummer",
+    "ProductKey",
+    "WeeksOut",
+    "Status",
+    "SalePriceIncVAT",
+    "ForecastPerWeek",
+    "ActualsPerWeek",
+    "Fcast_to_Actual",
+    "Supplier",
+    "HierarchyLevel1",
+    "HierarchyLevel2",
+    "DIorDOM",
+    "Seasonal",
+]
+
+
+def _load_dataset(path: str) -> pd.DataFrame:
+    """Load dataset saved by preprocess step."""
+    df = pd.read_csv(path, header=None, names=COLUMNS)
+    # cast categorical columns to category dtype
+    for col in [
+        "Supplier",
+        "HierarchyLevel1",
+        "HierarchyLevel2",
+        "DIorDOM",
+        "Seasonal",
+        "SpringSummer",
+        "Status",
+    ]:
+        if col in df.columns:
+            df[col] = df[col].astype("category")
+    return df
+
+
+def get_data_for_horizon(df: pd.DataFrame, horizon: int):
+    subset = df[df["WeeksOut"] == horizon].copy()
+    X = subset[FEATURES]
+    y = subset[TARGET]
+    cat_cols = X.select_dtypes(include=["category"]).columns
+    return X, y, cat_cols
+
+
+def build_model():
+    return lgb.LGBMClassifier(
+        objective="binary",
+        boosting_type="gbdt",
+        num_leaves=64,
+        learning_rate=0.05,
+        n_estimators=2000,
+        subsample=0.8,
+        colsample_bytree=0.8,
+        random_state=42,
+    )
+
+
+def train_and_evaluate(horizon, train_df, val_df):
+    X_train, y_train, cat_cols = get_data_for_horizon(train_df, horizon)
+    X_val, y_val, _ = get_data_for_horizon(val_df, horizon)
+    model = build_model()
+    model.fit(
+        X_train,
+        y_train,
+        eval_set=[(X_val, y_val)],
+        eval_metric=["auc", "average_precision"],
+        categorical_feature=list(cat_cols),
+        callbacks=[early_stopping(stopping_rounds=50), log_evaluation(100)],
+    )
+
+    # save model
+    os.makedirs(MODEL_DIR, exist_ok=True)
+    model_path = os.path.join(MODEL_DIR, f"model_horizon_{horizon}w.pkl")
+    with open(model_path, "wb") as f:
+        pickle.dump(model, f)
+
+    # save validation predictions for inspection
+    os.makedirs(PREDICTION_DIR, exist_ok=True)
+    y_pred = model.predict(X_val)
+    y_proba = model.predict_proba(X_val)[:, 1]
+    preds_df = X_val.copy()
+    preds_df["TrueLabel"] = y_val.values
+    preds_df["PredictedLabel"] = y_pred
+    preds_df["PredictedProb"] = y_proba
+    preds_df.to_csv(
+        os.path.join(PREDICTION_DIR, f"predictions_horizon_{horizon}w.csv"),
+        index=False,
+    )
+
+
+def main():
+    train_path = "/opt/ml/input/data/train/train.csv"
+    val_path = "/opt/ml/input/data/validation/validation.csv"
+    train_df = _load_dataset(train_path)
+    val_df = _load_dataset(val_path)
+
+    for horizon in HORIZONS:
+        train_and_evaluate(horizon, train_df, val_df)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `train.py` to train separate LightGBM models for each horizon using training and validation splits
- Revise `evaluate.py` to load per-horizon models, compute detailed metrics, and emit evaluation report

## Testing
- `python -m py_compile pipelines/sainsbury/train.py pipelines/sainsbury/evaluate.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b18d669b4c8331a208327b6316cd29